### PR TITLE
Added HTTP Version of NGINX sample configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ downloads in. This also gives you the ability to serve them, for example, like t
 	https://files.lolisafe.moe/yourFile.jpg
 
 Both cases require you to type the domain where the files will be served on the `domain` key below.
-Which one you use is ultimately up to you. Either way, I've provided a [sample config file for nginx](https://github.com/WeebDev/lolisafe/blob/master/nginx.sample.conf) that you can use to set it up quickly and painlessly!
+Which one you use is ultimately up to you. Either way, I've provided a sample config files for nginx that you can use to set it up quickly and painlessly!
+- [Normal Version](https://github.com/WeebDev/lolisafe/blob/master/nginx.sample.conf)
+- [SSL Version](https://github.com/WeebDev/lolisafe/blob/master/nginx-ssl.sample.conf)
 
 If you set `enableUserAccounts: true`, people will be able to create accounts on the service to keep track of their uploaded files and create albums to upload stuff to, pretty much like imgur does, but only through the API. Every user account has a token that the user can use to upload stuff through the API. You can find this token on the section called `Change your token` on the administration dashboard, and if it gets leaked or compromised you can renew it by clicking the button titled `Request new token`.
 

--- a/nginx-ssl.sample.conf
+++ b/nginx-ssl.sample.conf
@@ -1,5 +1,5 @@
 upstream backend {
-	server 127.0.0.1:3000; # Change to the port you specified on lolisafe
+	server 127.0.0.1:9999; # Change to the port you specified on lolisafe
 }
 
 server {

--- a/nginx-ssl.sample.conf
+++ b/nginx-ssl.sample.conf
@@ -1,0 +1,43 @@
+upstream backend {
+	server 127.0.0.1:3000; # Change to the port you specified on lolisafe
+}
+
+server {
+	listen 80;
+	listen [::]:80;
+	server_name lolisafe.moe;
+	return 301 https://$server_name$request_uri;
+}
+
+server {
+	listen 443 ssl http2;
+	listen [::]:443 ssl http2;
+
+	server_name lolisafe.moe;
+
+	ssl_certificate /path/to/your/fullchain.pem;
+	ssl_certificate_key /path/to/your/privkey.pem;
+	ssl_trusted_certificate /path/to/your/fullchain.pem;
+
+	client_max_body_size 100M; # Change this to the max file size you want to allow
+
+	location / {
+		add_header Access-Control-Allow-Origin *;
+		root /path/to/your/uploads/folder;
+		try_files $uri @proxy;
+	}
+
+	location @proxy {
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header Host $http_host;
+		proxy_set_header X-NginX-Proxy true;
+		proxy_pass http://backend;
+		proxy_redirect off;
+		proxy_http_version 1.1;
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header Connection "upgrade";
+		proxy_redirect off;
+		proxy_set_header X-Forwarded-Proto $scheme;
+	}
+}

--- a/nginx.sample.conf
+++ b/nginx.sample.conf
@@ -5,19 +5,8 @@ upstream backend {
 server {
 	listen 80;
 	listen [::]:80;
-	server_name lolisafe.moe;
-	return 301 https://$server_name$request_uri;
-}
-
-server {
-	listen 443 ssl http2;
-	listen [::]:443 ssl http2;
 
 	server_name lolisafe.moe;
-
-	ssl_certificate /path/to/your/fullchain.pem;
-	ssl_certificate_key /path/to/your/privkey.pem;
-	ssl_trusted_certificate /path/to/your/fullchain.pem;
 
 	client_max_body_size 100M; # Change this to the max file size you want to allow
 

--- a/nginx.sample.conf
+++ b/nginx.sample.conf
@@ -1,5 +1,5 @@
 upstream backend {
-	server 127.0.0.1:3000; # Change to the port you specified on lolisafe
+	server 127.0.0.1:9999; # Change to the port you specified on lolisafe
 }
 
 server {


### PR DESCRIPTION
- Renamed `nginx.sample.conf` to `nginx-ssl.sample.conf`
- Added `nginx.sample.conf` that only supports HTTPS
- Also matched the port in both configs to `9999` as `config.sample.js` has. 
- Updated the README to link to both configurations.