### PR TITLE
Ban of .com and .ps1 uploads

### DIFF
--- a/config.sample.js
+++ b/config.sample.js
@@ -35,11 +35,13 @@ module.exports = {
 
 	// Add file extensions here which should be blocked
 	blockedExtensions: [
+		'.jar',
 		'.exe',
 		'.msi',
 		'.com',
 		'.bat',
 		'.cmd',
+		'.scr',
 		'.ps1',
 		'.sh'
 	],

--- a/config.sample.js
+++ b/config.sample.js
@@ -36,9 +36,11 @@ module.exports = {
 	// Add file extensions here which should be blocked
 	blockedExtensions: [
 		'.exe',
+		'.msi',
+		'.com',
 		'.bat',
 		'.cmd',
-		'.msi',
+		'.ps1',
 		'.sh'
 	],
 


### PR DESCRIPTION
It seems that COM files can still be run in Windows, and they behave like any other executable.
PS1 files are scripts, so I put them on the list.