### PR TITLE
Patch to allow "retries" when generating random name

### DIFF
--- a/config.sample.js
+++ b/config.sample.js
@@ -62,6 +62,13 @@ module.exports = {
 		fileLength: 32,
 
 		/*
+			This option will limit how many times it will try to generate random names
+			for uploaded files. If this value is higher than 1, it will help in cases
+			where files with the same name already exists (higher chance with shorter file name length).
+		*/
+		maxTries: 1,
+
+		/*
 			NOTE: Thumbnails are only for the admin panel and they require you
 			to install a separate binary called graphicsmagick (http://www.graphicsmagick.org)
 			for images and ffmpeg (https://ffmpeg.org/) for video files

--- a/controllers/uploadController.js
+++ b/controllers/uploadController.js
@@ -17,18 +17,17 @@ const storage = multer.diskStorage({
 	destination: function(req, file, cb) {
 		cb(null, uploadDir);
 	},
-	filename: function(req, file, cb) {
-		for (let i = 0; i < maxTries; i++) {
+  	filename: function(req, file, cb) {
+		const access = i => {
 			const name = randomstring.generate(config.uploads.fileLength) + path.extname(file.originalname);
-			try {
-				fs.accessSync(path.join(uploadDir, name));
-				console.log(`A file named "${name}" already exists (${i + 1}/${maxTries}).`);
-			} catch (err) {
-				// Note: fs.accessSync() will throw an Error if a file with the same name does not exist
-				return cb(null, name);
-			}
-		}
-		return cb('Could not allocate a unique file name. Try again?');
+			fs.access(path.join(uploadDir, name), err => {
+				if (err) return cb(null, name);
+				console.log(`A file named "${name}" already exists (${++i}/${maxTries}).`);
+				if (i < maxTries) return access(i);
+				return cb('Could not allocate a unique file name. Try again?');
+			});
+		};
+		access(0);
 	}
 });
 


### PR DESCRIPTION
Looks good? I was debating on whether I should use 3 tries or 1 try for the default value, but in the end I decided to go with 1 try as to "sort of" follow the old behavior. Though technically speaking, the old behavior was to replace the old file, but in here it would return an error instead.

Also the comments in the config file could probably be phrased better but I'm having a mental block atm.


Other than that, do you mind sharing your eslint config file or something? I had to turn off 27 rules (28 including func-names in the package.json file) just so that none of the JS files show any errors/warnings. Though I can't really be sure whether it was my eslint not being setup properly or something ~~(*cough*, standard master race)~~.