### PR TITLE
fixed "add to album" error on uploads

### DIFF
--- a/controllers/uploadController.js
+++ b/controllers/uploadController.js
@@ -173,7 +173,7 @@ uploadsController.processFilesForDisplay = async (req, res, files, existingFiles
 
 	return res.json({
 		success: albumSuccess,
-		description: albumSuccess ? null : 'Warning: Successfully uploaded file(s) but unable to add to album.',
+		description: albumSuccess ? null : 'Warning: Error updating album.',
 		files: files.map(file => {
 			return {
 				name: file.name,

--- a/controllers/uploadController.js
+++ b/controllers/uploadController.js
@@ -71,7 +71,7 @@ uploadsController.upload = async (req, res, next) => {
 	return uploadsController.actuallyUpload(req, res, user, albumid);
 };
 
-uploadsController.actuallyUpload = async (req, res, userid, album) => {
+uploadsController.actuallyUpload = async (req, res, userid, albumid) => {
 	upload(req, res, async err => {
 		if (err) {
 			console.error(err);
@@ -114,7 +114,7 @@ uploadsController.actuallyUpload = async (req, res, userid, album) => {
 						size: file.size,
 						hash: fileHash,
 						ip: req.ip,
-						albumid: album,
+						albumid: albumid,
 						userid: userid !== undefined ? userid.id : null,
 						timestamp: Math.floor(Date.now() / 1000)
 					});
@@ -124,7 +124,7 @@ uploadsController.actuallyUpload = async (req, res, userid, album) => {
 				}
 
 				if (iteration === req.files.length) {
-					return uploadsController.processFilesForDisplay(req, res, files, existingFiles);
+					return uploadsController.processFilesForDisplay(req, res, files, existingFiles, albumid);
 				}
 				iteration++;
 			});
@@ -132,7 +132,7 @@ uploadsController.actuallyUpload = async (req, res, userid, album) => {
 	});
 };
 
-uploadsController.processFilesForDisplay = async (req, res, files, existingFiles) => {
+uploadsController.processFilesForDisplay = async (req, res, files, existingFiles, albumid) => {
 	let basedomain = config.domain;
 	if (files.length === 0) {
 		return res.json({
@@ -150,8 +150,30 @@ uploadsController.processFilesForDisplay = async (req, res, files, existingFiles
 	await db.table('files').insert(files);
 	for (let efile of existingFiles) files.push(efile);
 
-	res.json({
-		success: true,
+	for (let file of files) {
+		let ext = path.extname(file.name).toLowerCase();
+		if (utils.imageExtensions.includes(ext) || utils.videoExtensions.includes(ext)) {
+			file.thumb = `${basedomain}/thumbs/${file.name.slice(0, -ext.length)}.png`;
+			utils.generateThumbs(file);
+		}
+	}
+
+	let albumSuccess = true;
+	if (albumid) {
+		const editedAt = Math.floor(Date.now() / 1000)
+		albumSuccess = await db.table('albums')
+			.where('id', albumid)
+			.update('editedAt', editedAt)
+			.then(() => true)
+			.catch(error => {
+				console.log(error);
+				return false;
+			});
+	}
+
+	return res.json({
+		success: albumSuccess,
+		description: albumSuccess ? null : 'Warning: Successfully uploaded file(s) but unable to add to album.',
 		files: files.map(file => {
 			return {
 				name: file.name,
@@ -160,19 +182,6 @@ uploadsController.processFilesForDisplay = async (req, res, files, existingFiles
 			};
 		})
 	});
-
-	for (let file of files) {
-		let ext = path.extname(file.name).toLowerCase();
-		if (utils.imageExtensions.includes(ext) || utils.videoExtensions.includes(ext)) {
-			file.thumb = `${basedomain}/thumbs/${file.name.slice(0, -ext.length)}.png`;
-			utils.generateThumbs(file);
-		}
-
-		if (file.albumid) {
-			db.table('albums').where('id', file.albumid).update('editedAt', file.timestamp).then(() => {})
-				.catch(error => { console.log(error); res.json({ success: false, description: 'Error updating album' }); });
-		}
-	}
 };
 
 uploadsController.delete = async (req, res) => {

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -155,20 +155,21 @@ upload.prepareDropzone = function(){
 
 		// Handle the responseText here. For example, add the text to the preview element:
 
-		if(response.success === false){
-			var span = document.createElement('span');
-			span.innerHTML = response.description;
-			file.previewTemplate.querySelector('.link').appendChild(span);
-			return;
+		if (response.success === false) {
+			var p = document.createElement('p');
+			p.innerHTML = response.description;
+			file.previewTemplate.querySelector('.link').appendChild(p);
 		}
 
-		a = document.createElement('a');
-		a.href = response.files[0].url;
-		a.target = '_blank';
-		a.innerHTML = response.files[0].url;
-		file.previewTemplate.querySelector('.link').appendChild(a);
-		
-		file.previewTemplate.querySelector('.progress').style.display = 'none';
+		if (response.files[0].url) {
+			a = document.createElement('a');
+			a.href = response.files[0].url;
+			a.target = '_blank';
+			a.innerHTML = response.files[0].url;
+			file.previewTemplate.querySelector('.link').appendChild(a);
+
+			file.previewTemplate.querySelector('.progress').style.display = 'none';
+		}
 		
 	});
 


### PR DESCRIPTION
Fixed the way error when adding album is being handled.

![https://the.fiery.me/QA6p.png](https://the.fiery.me/QA6p.png)
I used "file(s)" since technically speaking you can upload more than one file at a time from the API (right?) :thinking: 

Btw, previously whenever a file could not be added to album, the error would never be shown to user, and it would throw an error in terminal about being unable to set headers and whatnots (https://github.com/WeebDev/lolisafe/issues/91).