### PR TITLE
Add basic Calmscan functionality 

### DIFF
--- a/config.sample.js
+++ b/config.sample.js
@@ -82,14 +82,14 @@ module.exports = {
 		*/
 		generateZips: true,
 
-        /* 
-            Scan files to see if they are a virus.
-            NOTE: This requires the package clamav installed.
-                Debian: sudo apt-get install clamav
-                Fedora: sudo yum install clamav
-                OS X:   sudo brew install clamav
-                Windows:Not Supported
-         */
+		/* 
+		    Scan files to see if they are a virus.
+		    NOTE: This requires the package clamav installed.
+			Debian: sudo apt-get install clamav
+			Fedora: sudo yum install clamav
+			OS X:   sudo brew install clamav
+			Windows:Not Supported
+		 */
 		virusScan: false
 	},
 

--- a/config.sample.js
+++ b/config.sample.js
@@ -80,7 +80,17 @@ module.exports = {
 			The file is generated when the user clicks the download button in the view
 			and is re-used if the album has not changed between download requests
 		*/
-		generateZips: true
+		generateZips: true,
+
+        /* 
+            Scan files to see if they are a virus.
+            NOTE: This requires the package clamav installed.
+                Debian: sudo apt-get install clamav
+                Fedora: sudo yum install clamav
+                OS X: sudo brew install clamav
+                Windows: Not Supported by ClamAV.
+         */
+		scanFiles: false
 	},
 
 	// Folder where to store logs

--- a/config.sample.js
+++ b/config.sample.js
@@ -87,10 +87,10 @@ module.exports = {
             NOTE: This requires the package clamav installed.
                 Debian: sudo apt-get install clamav
                 Fedora: sudo yum install clamav
-                OS X: sudo brew install clamav
-                Windows: Not Supported by ClamAV.
+                OS X:   sudo brew install clamav
+                Windows:Not Supported
          */
-		scanFiles: false
+		virusScan: false
 	},
 
 	// Folder where to store logs

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "bcrypt": "^1.0.3",
     "body-parser": "^1.18.2",
+    "clamscan": "^0.8.4",
     "express": "^4.16.1",
     "express-handlebars": "^3.0.0",
     "express-rate-limit": "^2.11.0",


### PR DESCRIPTION
Scans files when uploaded. As requested in #97 

Uses: https://github.com/kylefarris/clamscan
Requires: `clamav` installed.