### PR TITLE
Small nginx.config improvements

### DIFF
--- a/nginx-ssl.sample.conf
+++ b/nginx-ssl.sample.conf
@@ -2,6 +2,10 @@ upstream backend {
 	server 127.0.0.1:9999; # Change to the port you specified on lolisafe
 }
 
+map $sent_http_content_type $charset {
+	~^text/ utf-8;
+}
+
 server {
 	listen 80;
 	listen [::]:80;
@@ -14,12 +18,16 @@ server {
 	listen [::]:443 ssl http2;
 
 	server_name lolisafe.moe;
+	server_tokens off;
 
 	ssl_certificate /path/to/your/fullchain.pem;
 	ssl_certificate_key /path/to/your/privkey.pem;
 	ssl_trusted_certificate /path/to/your/fullchain.pem;
 
 	client_max_body_size 100M; # Change this to the max file size you want to allow
+
+	charset $charset;
+	charset_type *;
 
 	# Uncomment if you are running lolisafe behind CloudFlare.
 	# This requires NGINX compiled from source with:

--- a/nginx.sample.conf
+++ b/nginx.sample.conf
@@ -2,13 +2,21 @@ upstream backend {
 	server 127.0.0.1:9999; # Change to the port you specified on lolisafe
 }
 
+map $sent_http_content_type $charset {
+	~^text/ utf-8;
+}
+
 server {
 	listen 80;
 	listen [::]:80;
 
 	server_name lolisafe.moe;
+	server_tokens off;
 
 	client_max_body_size 100M; # Change this to the max file size you want to allow
+
+	charset $charset;
+	charset_type *;
 
 	# Uncomment if you are running lolisafe behind CloudFlare.
 	# This requires NGINX compiled from source with:


### PR DESCRIPTION
So that non-English text isn't mangled, all `text/*` types are sent with `utf-8` encoding by adding the following:
```
map $sent_http_content_type $charset {
    ~^text/ utf8;
}

server {
    // Other settings
    charset $charset;
    charset_types *;
}
```

I can't think of a good reason to send the nginx version in the headers, so, for what may as well be security theater, the following is added:
```
server_tokens off;
```