### PR TITLE
Fixes typo of charset_Type

### DIFF
--- a/nginx-ssl.sample.conf
+++ b/nginx-ssl.sample.conf
@@ -27,7 +27,7 @@ server {
 	client_max_body_size 100M; # Change this to the max file size you want to allow
 
 	charset $charset;
-	charset_type *;
+	charset_types *;
 
 	# Uncomment if you are running lolisafe behind CloudFlare.
 	# This requires NGINX compiled from source with:

--- a/nginx.sample.conf
+++ b/nginx.sample.conf
@@ -16,7 +16,7 @@ server {
 	client_max_body_size 100M; # Change this to the max file size you want to allow
 
 	charset $charset;
-	charset_type *;
+	charset_types *;
 
 	# Uncomment if you are running lolisafe behind CloudFlare.
 	# This requires NGINX compiled from source with:


### PR DESCRIPTION
Unknown directive `charset_type`, because the proper directive is `charset_types`. 