### PR TITLE
Fix: File Deletion for No Thumbnail in Album View

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -144,7 +144,7 @@ panel.getUploads = function(album = undefined, page = undefined){
 				if(item.thumb !== undefined)
 					div.innerHTML = `<a href="${item.file}" target="_blank"><img src="${item.thumb}"/></a><a class="button is-small is-danger is-outlined" title="Delete file" onclick="panel.deleteFile(${item.id})"><span class="icon is-small"><i class="fa fa-trash-o"></i></span></a>`;
 				else
-					div.innerHTML = `<a href="${item.file}" target="_blank"><h1 class="title">.${item.file.split('.').pop()}</h1></a>`;
+					div.innerHTML = `<a href="${item.file}" target="_blank"><h1 class="title">.${item.file.split('.').pop()}</h1></a><a class="button is-small is-danger is-outlined" title="Delete file" onclick="panel.deleteFile(${item.id})"><span class="icon is-small"><i class="fa fa-trash-o"></i></span></a>`;
 				table.appendChild(div);
 
 			}


### PR DESCRIPTION
If a file did not have a thumbnail the delete button would not render because I missed this `else` clause. :(