### PR TITLE
File extension bans

### DIFF
--- a/config.sample.js
+++ b/config.sample.js
@@ -41,9 +41,18 @@ module.exports = {
 		'.com',
 		'.bat',
 		'.cmd',
+		'.nt',
 		'.scr',
 		'.ps1',
-		'.sh'
+		'.psm1',
+		'.sh',
+		'.bash',
+		'.bsh',
+		'.csh',
+		'.bash_profile',
+		'.bashrc',
+		'.profile',
+		'.reg'
 	],
 
 	// Uploads config


### PR DESCRIPTION
More of #78.

`.nt` - turns out there's more Windows batch file extensions.
`.psm1` - PowerScript extension.
`.bash`, `.bsh`, `.csh`, `.bash_profile`, `.bashrc`, `.profile` - apparently those are valid bash script extensions.
`.reg` - overwrites Windows registry keys upon execution.