### PR TITLE
Getting rid of arrow functions to make code look cleaner

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -6,32 +6,32 @@ const tokenController = require('../controllers/tokenController');
 const authController = require('../controllers/authController');
 
 routes.get('/check', (req, res, next) => {
-	return res.json({
-		private: config.private,
-		maxFileSize: config.uploads.maxSize
-	});
+    return res.json({
+        private: config.private,
+        maxFileSize: config.uploads.maxSize
+    });
 });
 
-routes.post('/login', (req, res, next) => authController.verify(req, res, next));
-routes.post('/register', (req, res, next) => authController.register(req, res, next));
-routes.post('/password/change', (req, res, next) => authController.changePassword(req, res, next));
-routes.get('/uploads', (req, res, next) => uploadController.list(req, res, next));
-routes.get('/uploads/:page', (req, res, next) => uploadController.list(req, res, next));
-routes.post('/upload', (req, res, next) => uploadController.upload(req, res, next));
-routes.post('/upload/delete', (req, res, next) => uploadController.delete(req, res, next));
-routes.post('/upload/:albumid', (req, res, next) => uploadController.upload(req, res, next));
-routes.get('/album/get/:identifier', (req, res, next) => albumsController.get(req, res, next));
-routes.get('/album/zip/:identifier', (req, res, next) => albumsController.generateZip(req, res, next));
-routes.get('/album/:id', (req, res, next) => uploadController.list(req, res, next));
-routes.get('/album/:id/:page', (req, res, next) => uploadController.list(req, res, next));
-routes.get('/albums', (req, res, next) => albumsController.list(req, res, next));
-routes.get('/albums/:sidebar', (req, res, next) => albumsController.list(req, res, next));
-routes.post('/albums', (req, res, next) => albumsController.create(req, res, next));
-routes.post('/albums/delete', (req, res, next) => albumsController.delete(req, res, next));
-routes.post('/albums/rename', (req, res, next) => albumsController.rename(req, res, next));
-routes.get('/albums/test', (req, res, next) => albumsController.test(req, res, next));
-routes.get('/tokens', (req, res, next) => tokenController.list(req, res, next));
-routes.post('/tokens/verify', (req, res, next) => tokenController.verify(req, res, next));
-routes.post('/tokens/change', (req, res, next) => tokenController.change(req, res, next));
+routes.post('/login', authController.verify);
+routes.post('/register', authController.register);
+routes.post('/password/change', authController.changePassword);
+routes.get('/uploads', uploadController.list);
+routes.get('/uploads/:page', uploadController.list);
+routes.post('/upload', uploadController.upload);
+routes.post('/upload/delete', uploadController.delete);
+routes.post('/upload/:albumid', uploadController.upload);
+routes.get('/album/get/:identifier', albumsController.get);
+routes.get('/album/zip/:identifier', albumsController.generateZip);
+routes.get('/album/:id', uploadController.list);
+routes.get('/album/:id/:page', uploadController.list);
+routes.get('/albums', albumsController.list);
+routes.get('/albums/:sidebar', albumsController.list);
+routes.post('/albums', albumsController.create);
+routes.post('/albums/delete', albumsController.delete);
+routes.post('/albums/rename', albumsController.rename);
+routes.get('/albums/test', albumsController.test);
+routes.get('/tokens', tokenController.list);
+routes.post('/tokens/verify', tokenController.verify);
+routes.post('/tokens/change', tokenController.change);
 
 module.exports = routes;


### PR DESCRIPTION
Basically, there's no need in using functions to pass page handlers to express router. You can freely write just a "function name", because method signatures are the same. Such a small fix, but it makes code look much more cleaner.