### PR TITLE
Update package.json dependencies to the recent.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,38 +11,44 @@
     "url": "https://github.com/WeebDev/lolisafe/issues"
   },
   "engines": {
-    "node": ">=7.0.0"
+    "node": ">=8.0.0"
   },
   "license": "MIT",
+  "scripts": {
+    "start": "node ./lolisafe.js",
+    "pm2": "pm2 start --name lolisafe ./lolisafe.js",
+    "thumbs": "node ./scripts/thumbs.js",
+    "randver": "node -e \"console.log(require('randomstring').generate(10))\""
+  },
   "dependencies": {
-    "bcrypt": "^1.0.3",
-    "body-parser": "^1.18.2",
-    "express": "^4.16.1",
-    "express-handlebars": "^3.0.0",
-    "express-rate-limit": "^2.11.0",
+    "axios": "^0.18.0",
+    "bcrypt": "^3.0.1",
+    "body-parser": "^1.18.3",
+    "clamdjs": "^1.0.1",
+    "express": "^4.16.3",
+    "express-rate-limit": "^3.2.0",
     "fluent-ffmpeg": "^2.1.2",
     "gm": "^1.23.1",
-    "helmet": "^3.11.0",
+    "helmet": "^3.13.0",
     "jszip": "^3.1.5",
-    "knex": "^0.14.4",
-    "multer": "^1.3.0",
+    "knex": "^0.15.2",
+    "multer": "^1.3.1",
+    "mysql": "^2.16.0",
+    "nunjucks": "^3.1.3",
+    "path-complete-extname": "^1.0.0",
     "randomstring": "^1.1.5",
-    "sqlite3": "^3.1.13"
+    "snekfetch": "^4.0.4",
+    "sqlite3": "^4.0.2"
   },
   "devDependencies": {
-    "eslint": "^4.18.1",
-    "eslint-config-aqua": "^1.4.1"
+    "eslint": "^5.6.0",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-node": "^7.0.1",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.0"
   },
-  "eslintConfig": {
-    "extends": [
-      "aqua"
-    ],
-    "env": {
-      "browser": true,
-      "node": true
-    },
-    "rules": {
-      "func-names": 0
-    }
+  "resolutions": {
+    "chokidar": "^2.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
   "scripts": {
     "start": "node ./lolisafe.js",
     "pm2": "pm2 start --name lolisafe ./lolisafe.js",
-    "thumbs": "node ./scripts/thumbs.js",
-    "randver": "node -e \"console.log(require('randomstring').generate(10))\""
   },
   "dependencies": {
     "axios": "^0.18.0",


### PR DESCRIPTION
This upgrades all the depencides and makes node 8.0.0 or above required to be able to run lolisafe.


- # Changelog

**Node 8.0.0+ must be required to run lolisafe.**
**Scripts added to start and run lolisafe and pm2 startups.**
**axios upgrade to 0.18.0**
**bcrypt upgrade to 3.0.1**
**body-parser upgrade to 1.18.3**
**clamdjs upgrade to 1.0.1**
**express upgrade to 4.16.3**
**express-rate-limit upgrade to 3.2.0**
**helmet upgrade to 3.13.0**
**knex upgrade to 0.15.2**
**multer upgrade to 1.3.1**
**mysql upgrade to 2.16.0**
**nunjucks upgrade to 3.1.3**
**path-complete-extname upgrade to 1.0.0**
**snekfetch upgrade to 4.0.4**
**sqlite3 upgrade to 4.0.2**
** [X] Removed the randver and thumbs scripts as it is not included with regular lolisafe configuration and files.**
