### PR TITLE
add option to block empty file extensions

### DIFF
--- a/config.sample.js
+++ b/config.sample.js
@@ -55,6 +55,9 @@ module.exports = {
 		'.profile'
 	],
 
+	// Whether or not to allow files without extensions
+	blockEmptyExtension: false,
+
 	// Uploads config
 	uploads: {
 

--- a/controllers/uploadController.js
+++ b/controllers/uploadController.js
@@ -36,7 +36,11 @@ const upload = multer({
 	limits: { fileSize: config.uploads.maxSize },
 	fileFilter: function(req, file, cb) {
 		if (config.blockedExtensions !== undefined) {
-			if (config.blockedExtensions.some(extension => path.extname(file.originalname).toLowerCase() === extension)) {
+			const fileExtension = path.extname(file.originalname).toLowerCase();
+			if (config.blockEmptyExtension && !fileExtension) {
+				return cb('Files without extensions are not allowed');
+			}
+			if (config.blockedExtensions.some(extension => fileExtension === extension)) {
 				return cb('This file extension is not allowed');
 			}
 			return cb(null, true);


### PR DESCRIPTION
Fixes one part of https://github.com/WeebDev/lolisafe/issues/158, the other part (disabling empty files) is not easily achievable with multer and I didn't wanna mess around too much.