### PR TITLE
add deleteUrl for sharex

### DIFF
--- a/public/js/home.js
+++ b/public/js/home.js
@@ -190,7 +190,8 @@ upload.prepareShareX = function(){
   },\r\n\
   \"ResponseType\": \"Text\",\r\n\
   \"URL\": \"$json:files[0].url$\",\r\n\
-  \"ThumbnailURL\": \"$json:files[0].url$\"\r\n\
+  \"ThumbnailURL\": \"$json:files[0].url$\",\r\n\
+  \"DeletionURL\": \"$json:files[0].deleteUrl$\"\r\n\
 }";
 		var sharex_blob = new Blob([sharex_file], {type: "application/octet-binary"});
 		sharex_element.setAttribute("href", URL.createObjectURL(sharex_blob));

--- a/routes/api.js
+++ b/routes/api.js
@@ -19,6 +19,7 @@ routes.get('/uploads', (req, res, next) => uploadController.list(req, res, next)
 routes.get('/uploads/:page', (req, res, next) => uploadController.list(req, res, next));
 routes.post('/upload', (req, res, next) => uploadController.upload(req, res, next));
 routes.post('/upload/delete', (req, res, next) => uploadController.delete(req, res, next));
+routes.get('/upload/delete/:token/:id', (req, res, next) => uploadController.delete(req, res, next));
 routes.post('/upload/:albumid', (req, res, next) => uploadController.upload(req, res, next));
 routes.get('/album/get/:identifier', (req, res, next) => albumsController.get(req, res, next));
 routes.get('/album/zip/:identifier', (req, res, next) => albumsController.generateZip(req, res, next));


### PR DESCRIPTION
https://github.com/WeebDev/lolisafe/issues/123

It's really hacky and I don't like it. I'm not sure if ShareX supports just setting off a DELETE request instead of opening the URL in the browser, but that would definitely be a prettier solution.