### PR TITLE
Removed inactive sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,10 @@ Because of how nodejs apps work, if you want it attached to a domain name you wi
 - [dmca.gripe](https://dmca.gripe): a dmca-resistant, permanent file hosting service.
 - [safe.succmy.wang](https://safe.succmy.wang): A private clone with a ~~funny~~ bad name
 - [namir.in](https://namir.in): A private clone dedicated to best girl.
-- [safe.waliant.pw](https://safe.waliant.pw): A generic private clone for personal use.
 - [wtf.hyper.lol](https://wtf.hyper.lol): My personal clone with some ~~terrible~~ great changes.
 - [discordjs.moe](https://discordjs.moe): A まじ卍 as fuck copy of lolisafe.moe
 - [i.liich.me](https://i.liich.me): Another private clone with a different look.
 - [criminals.host](https://criminals.host): Redesigned, offshore by AZATEJ.
-- [vortex.64i.de](https://vortex.64i.de/): ShareX/WeebShit place for the 64i.de team and interested ones.
 - Feel free to add yours here.
 
 ## Author


### PR DESCRIPTION
Removed:
- safe.waliant.pw (Unresponsive, DNS has expired: https://securitytrails.com/domain/safe.waliant.pw/history/a)
- vortex.64i.de (Doesn't have lolisafe instance, just shows main page)