### PR TITLE
updated deps to make it work with node 10.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "bcrypt": "^1.0.3",
+    "bcrypt": "^3.0.4",
     "body-parser": "^1.18.2",
     "express": "^4.16.1",
     "express-handlebars": "^3.0.0",
@@ -27,7 +27,7 @@
     "multer": "^1.3.0",
     "randomstring": "^1.1.5",
     "sharp": "^0.21.0",
-    "sqlite3": "^3.1.13"
+    "sqlite3": "^4.0.6"
   },
   "devDependencies": {
     "eslint": "^4.18.1",


### PR DESCRIPTION
Updates dependencies for node 10.x and 11.x

Couldn't test under 7.x nor 8.x, but the npm pages of the dependencies don't mention incompatibilities with these versions. This should probably be tested.