### PR TITLE
fix: restore saveDuplicatesToAlbum column and fix sourceUrl nullable type

### DIFF
--- a/packages/backend/src/prisma/migrations/20251216120000_restore_save_duplicates_to_album/migration.sql
+++ b/packages/backend/src/prisma/migrations/20251216120000_restore_save_duplicates_to_album/migration.sql
@@ -1,0 +1,2 @@
+-- Restore column that was accidentally dropped by 20250705_add_s3pathstyle_setting
+ALTER TABLE "settings" ADD COLUMN "saveDuplicatesToAlbum" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/backend/src/structures/schemas/FileAsUser.ts
+++ b/packages/backend/src/structures/schemas/FileAsUser.ts
@@ -14,6 +14,6 @@ export const fileAsUserSchema = z
 		thumb: z.string().describe('The URL of the thumbnail of the file.'),
 		preview: z.string().describe('The URL of the preview of the file.'),
 		quarantine: z.boolean().optional().describe('Whether the file is quarantined.'),
-		sourceUrl: z.string().optional().describe('The source URL of the file.')
+		sourceUrl: z.string().nullable().optional().describe('The source URL of the file.')
 	})
 	.describe('The file object.');

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -50,7 +50,7 @@ export type File = {
 	preview?: string;
 	quarantine: boolean;
 	size: number;
-	sourceUrl?: string;
+	sourceUrl?: string | null;
 	thumb: string;
 	type: string;
 	url: string;


### PR DESCRIPTION
- Fix migration ordering bug that dropped `saveDuplicatesToAlbum` column
- Fix `sourceUrl` nullable type mismatch
